### PR TITLE
added importcommand to cmd __init__.py

### DIFF
--- a/drillsrs/cmd/__init__.py
+++ b/drillsrs/cmd/__init__.py
@@ -40,4 +40,5 @@ def get_all_commands() -> List[CommandBase]:
         ReviewCommand(),
         StatsCommand(),
         ExportCommand(),
+        ImportCommand(),
     ]


### PR DESCRIPTION
ImportCommand() seemed to be missing from get_all_commands()